### PR TITLE
Actualiza el .gitignore

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,28 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+
+# IntelliJ
+/out/
+
+### Maven template
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# project release file
+/*.war


### PR DESCRIPTION
### Descripción
Ignora archivos no necesarios para el repositorio como _builds_, _maven outputs_, etc.

### Referencia
https://www.toptal.com/developers/gitignore/api/maven